### PR TITLE
Support multiline alert log in integrator messages

### DIFF
--- a/integrations/slack
+++ b/integrations/slack
@@ -36,9 +36,13 @@ fi
 postfile=`mktemp`
 
 
-echo 'payload={"username":"OSSEC2slack Integration from '$alertlocation'", "icon_emoji": ":ghost:", "text": "OSSEC Alert\n```'$alertdate $alertlocation'\nRule:'$ruleid' (level '$alertlevel'): '$ruledescription'\nIP:'$srcip'\n'$alertlog'\n```"}' > $postfile
+echo -n 'payload={"username":"OSSEC2slack Integration from ' > $postfile
+echo -n "$alertlocation" >> $postfile
+echo -n '", "icon_emoji": ":ghost:", "text": "OSSEC Alert\n```' >> $postfile
+echo -n "$alertdate $alertlocation\nRule:$ruleid (level $alertlevel): $ruledescription\nIP:$srcip\n$alertlog\n" >> $postfile
+echo -n '```"}' >> $postfile
 
-res=`curl -s --data @$postfile "$WEBHOOK"`
+res=`curl -s --data-binary @$postfile "$WEBHOOK"`
 echo $res | grep "ok" >/dev/null 2>&1
 if [ $? = 0 ]; then
     echo "`date` $0 Slack integration ran successfully" >> ${PWD}/logs/integrations.log

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -64,7 +64,7 @@ void OS_LogOutput(Eventinfo *lf)
     printf(
            "** Alert %d.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
-            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%.1256s\n",
+            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%s\n",
             lf->time,
             __crt_ftell,
             lf->generated_rule->alert_opts & DO_MAILALERT?" mail ":"",
@@ -110,7 +110,7 @@ void OS_LogOutput(Eventinfo *lf)
         char **lasts = lf->generated_rule->last_events;
         while(*lasts)
         {
-            printf("%.1256s\n",*lasts);
+            printf("%s\n",*lasts);
             lasts++;
         }
         lf->generated_rule->last_events[0] = NULL;
@@ -132,7 +132,7 @@ void OS_Log(Eventinfo *lf)
     fprintf(_aflog,
             "** Alert %d.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
-            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%.1256s\n",
+            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%s\n",
             lf->time,
             __crt_ftell,
             lf->generated_rule->alert_opts & DO_MAILALERT?" mail ":"",
@@ -178,7 +178,7 @@ void OS_Log(Eventinfo *lf)
         char **lasts = lf->generated_rule->last_events;
         while(*lasts)
         {
-            fprintf(_aflog,"%.1256s\n",*lasts);
+            fprintf(_aflog,"%s\n",*lasts);
             lasts++;
         }
         lf->generated_rule->last_events[0] = NULL;

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -301,7 +301,20 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                             tmpstr++;
                         }
                     }
-                    fprintf(fp, "alertdate='%s'\nalertlocation='%s'\nruleid='%d'\nalertlevel='%d'\nruledescription='%s'\nalertlog='%s'\nsrcip='%s'", al_data->date, al_data->location, al_data->rule, al_data->level, al_data->comment, al_data->log[0], al_data->srcip == NULL?"":al_data->srcip);
+                    fprintf(fp, "alertdate='%s'\n", al_data->date);
+                    fprintf(fp, "alertlocation='%s'\n", al_data->location);
+                    fprintf(fp, "ruleid='%d'\n", al_data->rule);
+                    fprintf(fp, "alertlevel='%d'\n", al_data->level);
+                    fprintf(fp, "ruledescription='%s'\n", al_data->comment);
+                    fprintf(fp, "alertlog='%s", al_data->log[0]);
+                    int log_i = 1;
+                    while(al_data->log[log_i])
+                    {
+                        fprintf(fp, "\n%s", al_data->log[log_i]);
+                        log_i++;
+                    }
+                    fprintf(fp, "'\n");
+                    fprintf(fp, "srcip='%s'\n", al_data->srcip == NULL ? "" : al_data->srcip);
                     temp_file_created = 1;
                     fclose(fp);
                 }

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -345,7 +345,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 os_strdup(p, user);
             }
             /* It is a log message */
-            else if(log_size < 20)
+            else if(log_size < 30)
             {
                 os_clearnl(str,p);
 

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -169,7 +169,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
             }
 
             z = strlen(p) - strlen(m);
-            os_realloc(alertid, (z + 1)*sizeof(char *), alertid);
+            os_realloc(alertid, (z + 1)*sizeof(char), alertid);
             strncpy(alertid, p, z);
             alertid[z] = '\0';
             

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -125,7 +125,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
     while(fgets(str, OS_BUFFER_SIZE, fp) != NULL)
     {
         
-        /* Enf of alert */
+        /* End of alert */
         if(strcmp(str, "\n") == 0 && log_size > 0)
         {
             /* Found in here */

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -345,7 +345,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 os_strdup(p, user);
             }
             /* It is a log message */
-            else if(log_size < 30)
+            else if(log_size < 40)
             {
                 os_clearnl(str,p);
 
@@ -365,6 +365,14 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 
                 os_realloc(log, (log_size +2)*sizeof(char *), log);
                 os_strdup(str, log[log_size]); 
+                log_size++;
+                log[log_size] = NULL;
+            }
+            /* It is a very long log message */
+            else if(log_size == 40)
+            {
+                os_realloc(log, (log_size +2)*sizeof(char *), log);
+                os_strdup("--More--", log[log_size]);
                 log_size++;
                 log[log_size] = NULL;
             }


### PR DESCRIPTION
Fill the alertlog integrator variable using every line of alert log, not just the first one.

Also increases log limit sizes.
